### PR TITLE
fix #28

### DIFF
--- a/src/DefaultPeerStorage.cc
+++ b/src/DefaultPeerStorage.cc
@@ -90,6 +90,11 @@ void DefaultPeerStorage::addUniqPeer(const std::shared_ptr<Peer>& peer)
 
 bool DefaultPeerStorage::addPeer(const std::shared_ptr<Peer>& peer)
 {
+  if (peer->getPort() == 0) {
+    A2_LOG_TRACE(fmt("Adding %s:%u is rejected because port is 0.",
+                     peer->getIPAddress().c_str(), peer->getPort()));
+    return false;
+  }
   if (unusedPeers_.size() >= maxPeerListSize_) {
     A2_LOG_TRACE(fmt("Adding %s:%u is rejected, since unused peer list is full "
                      "(%lu peers > %lu)",

--- a/src/RpcMethodImpl.cc
+++ b/src/RpcMethodImpl.cc
@@ -1081,12 +1081,7 @@ void gatherPeer(List* peers, const std::shared_ptr<PeerStorage>& ps,
       peerEntry->put(KEY_PEER_CLIENT_NAME, peer->getClientName());
     }
     peerEntry->put(KEY_IP, peer->getIPAddress());
-    if (peer->isIncomingPeer()) {
-      peerEntry->put(KEY_PORT, VLB_ZERO);
-    }
-    else {
-      peerEntry->put(KEY_PORT, util::uitos(peer->getPort()));
-    }
+    peerEntry->put(KEY_PORT, util::uitos(peer->getPort()));
     peerEntry->put(KEY_BITFIELD,
                    util::toHex(peer->getBitfield(), peer->getBitfieldLength()));
     peerEntry->put(KEY_AM_CHOKING, peer->amChoking() ? VLB_TRUE : VLB_FALSE);

--- a/src/bittorrent_helper.cc
+++ b/src/bittorrent_helper.cc
@@ -876,10 +876,13 @@ std::pair<std::string, uint16_t> unpackcompact(const unsigned char* compact,
   int portOffset = family == AF_INET ? 4 : 16;
   char buf[NI_MAXHOST];
   if (inetNtop(family, compact, buf, sizeof(buf)) == 0) {
-    r.first = buf;
     uint16_t portN;
     memcpy(&portN, compact + portOffset, sizeof(portN));
-    r.second = ntohs(portN);
+    auto port = ntohs(portN);
+    if (port != 0) {
+      r.first = buf;
+      r.second = port;
+    }
   }
   return r;
 }

--- a/src/bittorrent_helper.h
+++ b/src/bittorrent_helper.h
@@ -293,7 +293,7 @@ void extractPeer(const ValueBase* peerData, int family, OutputIterator dest)
         const unsigned char* end = base + length;
         for (; base != end; base += unit) {
           std::pair<std::string, uint16_t> p = unpackcompact(base, family_);
-          if (p.first.empty()) {
+          if (p.first.empty() || p.second == 0) {
             continue;
           }
           *dest_++ = std::make_shared<Peer>(p.first, p.second);


### PR DESCRIPTION
## RPC 对传入连接输出 port=0

传入连接的 Peer 创建时用的是 TCP 源端口，这本身是一个有效值。扩展握手走完后 `incoming_` 会变成 false，端口也会被更新为真实的监听端口。但如果扩展握手没走完或者对方没发 tcpPort，`incoming_` 就一直为 true，此时 `getPort()` 拿到的其实是 TCP 源端口——但代码直接拿 VLB_ZERO 盖成了 "0"。

**文件**: [`src/RpcMethodImpl.cc#L1084`](https://github.com/AnInsomniacy/aria2-next/blob/d39b03b9a6645b396af29fd2edd1c0dd95972ea7/src/RpcMethodImpl.cc#L1084)

```cpp
if (peer->isIncomingPeer()) {
    peerEntry->put(KEY_PORT, VLB_ZERO);   // 源端口被丢弃了
} else {
    peerEntry->put(KEY_PORT, util::uitos(peer->getPort()));
}
```

**建议修复**: 去掉 `isIncomingPeer()` 分支，统一输出 `getPort()`。扩展握手成功后 `incoming_` 已为 false，走的本来就是 else 分支，不受影响；没成功时输出 TCP 源端口也比硬编码 "0" 更有意义。
```cpp
peerEntry->put(KEY_PORT, util::uitos(peer->getPort()));
```

---

## 紧凑格式 extractPeer 缺少 port=0 过滤

紧凑格式解析 peer 列表时只检查了 IP 是不是空的，没管端口是不是 0。字典格式反而是有检查的，同一个函数里两种格式的处理不一致。

**文件**: [`src/bittorrent_helper.h#L285`](https://github.com/AnInsomniacy/aria2-next/blob/d39b03b9a6645b396af29fd2edd1c0dd95972ea7/src/bittorrent_helper.h#L285)

```cpp
virtual void visit(const String& peerData) override
{
    int unit = family_ == AF_INET ? 6 : 18;
    size_t length = peerData.s().size();
    if (length % unit == 0) {
        const unsigned char* base =
            reinterpret_cast<const unsigned char*>(peerData.s().data());
        const unsigned char* end = base + length;
        for (; base != end; base += unit) {
            std::pair<std::string, uint16_t> p = unpackcompact(base, family_);
            if (p.first.empty()) {          // 只检查了 IP
                continue;
            }
            *dest_++ = std::make_shared<Peer>(p.first, p.second);  // 没检查 port
        }
    }
}
```

字典格式的版本是有校验的 ([`src/bittorrent_helper.h#L316`](https://github.com/AnInsomniacy/aria2-next/blob/d39b03b9a6645b396af29fd2edd1c0dd95972ea7/src/bittorrent_helper.h#L316)):

```cpp
const Integer* port = downcast<Integer>(peerDict->get(PORT));
if (!ip || !port || !(0 < port->i() && port->i() < 65536)) {
    continue;
}
```

**受影响路径**:
- HTTP tracker 紧凑模式 ([`DefaultBtAnnounce.cc#L345`](https://github.com/AnInsomniacy/aria2-next/blob/d39b03b9a6645b396af29fd2edd1c0dd95972ea7/src/DefaultBtAnnounce.cc#L345))
- UDP tracker ([`DefaultBtAnnounce.cc#L379`](https://github.com/AnInsomniacy/aria2-next/blob/d39b03b9a6645b396af29fd2edd1c0dd95972ea7/src/DefaultBtAnnounce.cc#L379))
- PEX 交换 ([`UTPexExtensionMessage.cc#L209`](https://github.com/AnInsomniacy/aria2-next/blob/d39b03b9a6645b396af29fd2edd1c0dd95972ea7/src/UTPexExtensionMessage.cc#L209))
- DHT get_peers 回复 ([`DHTMessageFactoryImpl.cc#L444`](https://github.com/AnInsomniacy/aria2-next/blob/d39b03b9a6645b396af29fd2edd1c0dd95972ea7/src/DHTMessageFactoryImpl.cc#L444))

**建议修复**: 在 `if (p.first.empty())` 的条件中加上 `|| p.second == 0`，与现有风格一致（继续用 `continue` 跳过无效条目）。

---

## unpackcompact 不验证端口

`unpackcompact` 把端口从网络字节序解码出来就直接返回了，没检查解码结果是不是 0。所以哪怕上层调用者想过滤，也得自己再来一遍。

**文件**: [`src/bittorrent_helper.cc#L872`](https://github.com/AnInsomniacy/aria2-next/blob/d39b03b9a6645b396af29fd2edd1c0dd95972ea7/src/bittorrent_helper.cc#L872)

```cpp
std::pair<std::string, uint16_t> unpackcompact(const unsigned char* compact,
                                               int family)
{
    std::pair<std::string, uint16_t> r;
    int portOffset = family == AF_INET ? 4 : 16;
    char buf[NI_MAXHOST];
    if (inetNtop(family, compact, buf, sizeof(buf)) == 0) {
        r.first = buf;
        uint16_t portN;
        memcpy(&portN, compact + portOffset, sizeof(portN));
        r.second = ntohs(portN);            // 没管 port 是不是 0
    }
    return r;
}
```

**建议修复**: 解码 `portN` 后判断是否为 0，若是则不设置 `r.first`（保持为空），与 `inetNtop` 失败时的返回模式一致：
```cpp
uint16_t portN;
memcpy(&portN, compact + portOffset, sizeof(portN));
auto port = ntohs(portN);
if (port != 0) {
    r.first = buf;
    r.second = port;
}
```

---

## DefaultPeerStorage 不拦截 port=0

`addPeer` 里面检查了列表大小、IP 加 OrigPort 是否重复、是否在阻止列表里、是否被临时拒绝——唯独没看端口是不是 0。所以前面漏进来的 port=0 的 Peer 到这里也被照单全收。

**文件**: [`src/DefaultPeerStorage.cc#L82`](https://github.com/AnInsomniacy/aria2-next/blob/d39b03b9a6645b396af29fd2edd1c0dd95972ea7/src/DefaultPeerStorage.cc#L82)

```cpp
bool DefaultPeerStorage::addPeer(const std::shared_ptr<Peer>& peer)
{
    // 列表大小、重复、阻止列表、临时拒绝都检查了
    // 就是没检查 peer->getPort() == 0
    ...
    unusedPeers_.push_back(peer);           // port=0 也被加进去了
}
```

**建议修复**: 在文件头部现有各检查（列表满、重复、阻止列表）之前，按相同模式增加端口检查：
```cpp
if (peer->getPort() == 0) {
    A2_LOG_TRACE(fmt("Adding %s:%u is rejected because port is 0.",
                     peer->getIPAddress().c_str(), peer->getPort()));
    return false;
}
```

---

## 实际影响

port=0 的 Peer 进入 `unusedPeers_` 之后，`PeerInitiateConnectionCommand` 会去连 `ip:0`，连不上之后被标记为临时拒绝。白占一个连接槽位，浪费资源。
